### PR TITLE
Add case insensitive search for descriptions

### DIFF
--- a/search.php
+++ b/search.php
@@ -47,7 +47,7 @@ foreach ($data as $key => $result){
 
 
     $value = strtolower(trim($result->title));
-    $description = utf8_decode(strip_tags($result->description));
+    $description = utf8_decode(strip_tags(strtolower($result->description)));
 
     $new_key = $type.$result->title;
 


### PR DESCRIPTION
This also fixes the issue I was having with the ruby API search, as it wasn't matching the capitalized class names in the description.
