### PR TITLE
Updated Bootstrap search string to new Bootstrap 3 URL

### DIFF
--- a/info.plist
+++ b/info.plist
@@ -1436,7 +1436,7 @@ end tell</string>
 				<key>plusspaces</key>
 				<false/>
 				<key>url</key>
-				<string>https://www.google.co.uk/search?q=site%3Atwitter.github.com%2Fbootstrap+{query}</string>
+				<string>https://www.google.com/search?q=site%3Agetbootstrap.com+{query}</string>
 				<key>utf8</key>
 				<true/>
 			</dict>


### PR DESCRIPTION
I updated the site: search URL to **getbootstrap.com** and I also switched the Google URL to **.com** to make it more universal. :+1: 

Referenced in : #40
